### PR TITLE
feat: add Solarized Dark, One Dark, and Gruvbox themes

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -133,6 +133,60 @@
   --glass-border: rgba(48, 54, 61, 0.8);
 }
 
+/* ── Theme: Solarized Dark ── */
+[data-theme="solarized-dark"] {
+  --term-bg: #002b36;
+  --term-bg-light: #073642;
+  --term-bg-panel: #586e75;
+  --term-fg: #839496;
+  --term-fg-dim: #657b83;
+  --term-green: #859900;
+  --term-blue: #268bd2;
+  --term-yellow: #b58900;
+  --term-red: #dc322f;
+  --term-purple: #6c71c4;
+  --term-cyan: #2aa198;
+  --term-orange: #cb4b16;
+  --term-pink: #d33682;
+  --glass-border: rgba(88, 110, 117, 0.4);
+}
+
+/* ── Theme: One Dark ── */
+[data-theme="one-dark"] {
+  --term-bg: #282c34;
+  --term-bg-light: #2c323c;
+  --term-bg-panel: #353b45;
+  --term-fg: #abb2bf;
+  --term-fg-dim: #5c6370;
+  --term-green: #98c379;
+  --term-blue: #61afef;
+  --term-yellow: #e5c07b;
+  --term-red: #e06c75;
+  --term-purple: #c678dd;
+  --term-cyan: #56b6c2;
+  --term-orange: #d19a66;
+  --term-pink: #c678dd;
+  --glass-border: rgba(92, 99, 112, 0.4);
+}
+
+/* ── Theme: Gruvbox ── */
+[data-theme="gruvbox"] {
+  --term-bg: #282828;
+  --term-bg-light: #3c3836;
+  --term-bg-panel: #504945;
+  --term-fg: #ebdbb2;
+  --term-fg-dim: #928374;
+  --term-green: #b8bb26;
+  --term-blue: #83a598;
+  --term-yellow: #fabd2f;
+  --term-red: #fb4934;
+  --term-purple: #d3869b;
+  --term-cyan: #8ec07c;
+  --term-orange: #fe8019;
+  --term-pink: #d3869b;
+  --glass-border: rgba(146, 131, 116, 0.4);
+}
+
 body {
   background: var(--term-bg);
   color: var(--term-fg);

--- a/components/terminal-themes.tsx
+++ b/components/terminal-themes.tsx
@@ -15,6 +15,9 @@ export const THEMES = [
   { id: 'nord', name: 'Nord', accent: '#81a1c1' },
   { id: 'monokai', name: 'Monokai', accent: '#a6e22e' },
   { id: 'github-dark', name: 'GitHub Dark', accent: '#58a6ff' },
+  { id: 'solarized-dark', name: 'Solarized Dark', accent: '#268bd2' },
+  { id: 'one-dark', name: 'One Dark', accent: '#61afef' },
+  { id: 'gruvbox', name: 'Gruvbox', accent: '#b8bb26' },
 ] as const
 
 export type ThemeId = (typeof THEMES)[number]['id']


### PR DESCRIPTION
## What does this PR do?

Adds three new professional color themes to the terminal-ui library: Solarized Dark, One Dark, and Gruvbox.

## Type of Change

- [x] 🎨 New theme

## Checklist

- [x] All CSS variables defined
- [x] Colors follow official theme specs
- [x] Build passes (`pnpm run build`)
- [x] Tested locally## What does this PR do?

<!-- Brief description of the changes -->

Closes #<!-- issue number -->

## Type of Change

<!-- Check all that apply -->

- [ ] 🎨 New theme
- [ ] 📦 New component
- [ ] 🐛 Bug fix
- [ ] 📚 Documentation
- [ ] ✨ Enhancement
- [ ] 🔧 Refactor

## Screenshots

<!-- If UI changes, add before/after screenshots -->

**Before:**
<!-- screenshot or "N/A" -->

**After:**
<!-- screenshot -->

## Checklist

- [ ] Code follows the existing style
- [ ] Component is documented (JSDoc comments)
- [ ] Example added to playground (if applicable)
- [ ] Build passes (`pnpm run build`)
- [ ] No console errors or warnings
- [ ] Tested locally

## Additional Notes

<!-- Any other context, implementation details, or questions -->
