### PR TITLE
feat: add TerminalProgress component and demo command

### DIFF
--- a/components/terminal-pane.tsx
+++ b/components/terminal-pane.tsx
@@ -11,13 +11,14 @@ import {
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { useTheme, THEMES, type ThemeId } from '@/components/terminal-themes'
 import { cn } from '@/lib/utils'
+import { TerminalProgress } from './terminal-progress'
 
 type OutputStyle = 'normal' | 'success' | 'error' | 'info' | 'warning' | 'dim'
 
 interface Line {
   id: number
   kind: 'command' | 'output'
-  text: string
+  text: string | React.ReactNode
   style?: OutputStyle
 }
 
@@ -136,6 +137,7 @@ export function TerminalPane({
             out('  theme [name]     switch theme'),
             out('  split            split terminal pane'),
             out('  tab              open new tab'),
+            out('  progress         show progress bar demo'),
             out('  clear            clear screen'),
             out(''),
             out('  ↑/↓              command history', 'dim'),
@@ -288,6 +290,24 @@ export function TerminalPane({
         case 'tab':
           push([cmdLine, out('Opening new tab...', 'info')])
           onNewTab?.()
+          return
+
+        case 'progress':
+          push([
+            cmdLine,
+            out('Starting installation...', 'info'),
+            {
+              id: nextId(),
+              kind: 'output',
+              text: <TerminalProgress percent={45} label="Fetching packages" />,
+            },
+            {
+              id: nextId(),
+              kind: 'output',
+              text: <TerminalProgress percent={100} label="Building assets" />,
+            },
+            out('Installation complete!', 'success'),
+          ])
           return
 
         default:

--- a/components/terminal-progress.tsx
+++ b/components/terminal-progress.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import { ReactNode } from 'react'
+
+export interface TerminalProgressProps {
+  /**
+   * Progress percentage (0-100)
+   */
+  percent: number
+  /**
+   * Optional label text to display before the progress bar
+   */
+  label?: string | ReactNode
+  /**
+   * Width of the progress bar in characters (default: 20)
+   */
+  width?: number
+  /**
+   * Character to use for filled portion (default: '█')
+   */
+  filled?: string
+  /**
+   * Character to use for empty portion (default: '░')
+   */
+  empty?: string
+  /**
+   * Whether to show the percentage text (default: true)
+   */
+  showPercent?: boolean
+}
+
+/**
+ * Displays a terminal-style progress bar with optional label and percentage.
+ * Renders a visual progress indicator using Unicode block characters, commonly used
+ * for showing installation, download, or processing progress in terminal applications.
+ * 
+ * @param percent - Progress percentage (0-100), will be clamped to valid range
+ * @param label - Optional label text displayed before the progress bar
+ * @param width - Progress bar width in characters (default: 20)
+ * @param filled - Character for filled portion (default: '█')
+ * @param empty - Character for empty portion (default: '░')
+ * @param showPercent - Whether to show percentage text (default: true)
+ * 
+ * @example
+ * ```tsx
+ * <TerminalProgress percent={75} label="Installing..." />
+ * // Output: Installing... [███████████████░░░░░] 75%
+ * 
+ * <TerminalProgress percent={45} label="Downloading" width={30} />
+ * // Output: Downloading [█████████████░░░░░░░░░░░░░░░░░░] 45%
+ * 
+ * <TerminalProgress percent={100} showPercent={false} />
+ * // Output: [████████████████████]
+ * ```
+ */
+export function TerminalProgress({
+  percent,
+  label,
+  width = 20,
+  filled = '█',
+  empty = '░',
+  showPercent = true,
+}: TerminalProgressProps) {
+  // Clamp percentage to 0-100 range
+  const clampedPercent = Math.max(0, Math.min(100, percent))
+  
+  // Calculate filled and empty segments
+  const filledCount = Math.round((clampedPercent / 100) * width)
+  const emptyCount = width - filledCount
+  
+  // Build the progress bar string
+  const bar = filled.repeat(filledCount) + empty.repeat(emptyCount)
+  
+  return (
+    <div className="flex items-center gap-2 text-[var(--term-fg)] font-mono text-sm">
+      {label && (
+        <span className="text-[var(--term-fg-dim)] flex-shrink-0">
+          {label}
+        </span>
+      )}
+      <span className="text-[var(--term-green)] flex-shrink-0">
+        [{bar}]
+      </span>
+      {showPercent && (
+        <span className="text-[var(--term-fg-dim)] flex-shrink-0 min-w-[4ch]">
+          {clampedPercent}%
+        </span>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## What does this PR do?

Introduces the `TerminalProgress` component for rendering terminal-style progress bars. Also adds a `progress` command to the terminal pane to demonstrate the component in action.

## Type of Change

- [x] 📦 New component

## Checklist

- [x] Code follows the existing style
- [x] Component is documented (JSDoc comments)
- [x] Example added to playground (demo command added)
- [x] Build passes (`pnpm run build`)
- [x] Tested locally## What does this PR do?

<!-- Brief description of the changes -->

Closes #<!-- issue number -->

## Type of Change

<!-- Check all that apply -->

- [ ] 🎨 New theme
- [ ] 📦 New component
- [ ] 🐛 Bug fix
- [ ] 📚 Documentation
- [ ] ✨ Enhancement
- [ ] 🔧 Refactor

## Screenshots

<!-- If UI changes, add before/after screenshots -->

**Before:**
<!-- screenshot or "N/A" -->

**After:**
<!-- screenshot -->

## Checklist

- [ ] Code follows the existing style
- [ ] Component is documented (JSDoc comments)
- [ ] Example added to playground (if applicable)
- [ ] Build passes (`pnpm run build`)
- [ ] No console errors or warnings
- [ ] Tested locally

## Additional Notes

<!-- Any other context, implementation details, or questions -->
