### PR TITLE
feat: add Catppuccin Mocha theme

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -187,6 +187,24 @@
   --glass-border: rgba(146, 131, 116, 0.4);
 }
 
+/* ── Theme: Catppuccin Mocha ── */
+[data-theme="catppuccin-mocha"] {
+  --term-bg: #1e1e2e;
+  --term-bg-light: #242435;
+  --term-bg-panel: #313244;
+  --term-fg: #cdd6f4;
+  --term-fg-dim: #a6adc8;
+  --term-green: #a6e3a1;
+  --term-blue: #89b4fa;
+  --term-yellow: #f9e2af;
+  --term-red: #f38ba8;
+  --term-purple: #cba6f7;
+  --term-cyan: #94e2d5;
+  --term-orange: #fab387;
+  --term-pink: #f5c2e7;
+  --glass-border: rgba(69, 71, 90, 0.6);
+}
+
 body {
   background: var(--term-bg);
   color: var(--term-fg);

--- a/components/terminal-themes.tsx
+++ b/components/terminal-themes.tsx
@@ -18,6 +18,7 @@ export const THEMES = [
   { id: 'solarized-dark', name: 'Solarized Dark', accent: '#268bd2' },
   { id: 'one-dark', name: 'One Dark', accent: '#61afef' },
   { id: 'gruvbox', name: 'Gruvbox', accent: '#b8bb26' },
+  { id: 'catppuccin-mocha', name: 'Catppuccin Mocha', accent: '#cba6f7' },
 ] as const
 
 export type ThemeId = (typeof THEMES)[number]['id']


### PR DESCRIPTION
## What it does

Adds the [Catppuccin Mocha](https://github.com/catppuccin/catppuccin) color theme to the terminal UI.

Catppuccin is one of the most popular community color schemes — warm pastel tones on a dark base. Mocha is the darkest variant and fits well alongside the existing themes (Dracula, Nord, Monokai, GitHub Dark).

## Changes

- **`app/globals.css`** — Added `[data-theme="catppuccin-mocha"]` block with all 15 CSS variables mapped to official Catppuccin Mocha palette colors
- **`components/terminal-themes.tsx`** — Registered the new theme in the `THEMES` array with Mauve (`#cba6f7`) as the accent color

## Color mapping

| Variable | Color | Catppuccin Token |
|----------|-------|-----------------|
| `--term-bg` | `#1e1e2e` | Base |
| `--term-bg-light` | `#242435` | Base + lightened |
| `--term-bg-panel` | `#313244` | Surface0 |
| `--term-fg` | `#cdd6f4` | Text |
| `--term-fg-dim` | `#a6adc8` | Subtext0 |
| `--term-green` | `#a6e3a1` | Green |
| `--term-blue` | `#89b4fa` | Blue |
| `--term-yellow` | `#f9e2af` | Yellow |
| `--term-red` | `#f38ba8` | Red |
| `--term-purple` | `#cba6f7` | Mauve |
| `--term-cyan` | `#94e2d5` | Teal |
| `--term-orange` | `#fab387` | Peach |
| `--term-pink` | `#f5c2e7` | Pink |
| `--glass-border` | `rgba(69, 71, 90, 0.6)` | Surface1 @ 60% |

## How to test

1. `pnpm install && pnpm run dev`
2. Right-click in the terminal → Theme → Catppuccin Mocha
3. Verify all text, prompts, and UI elements use the correct pastel palette