### PR TITLE
ci: add PR quality gate (typecheck + build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    name: Typecheck & Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Build
+        run: pnpm build

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 > Beautiful terminal-like UI components for the web. Build CLI experiences in React.
 
+[![CI](https://github.com/OpenKnots/terminal-ui/actions/workflows/ci.yml/badge.svg)](https://github.com/OpenKnots/terminal-ui/actions/workflows/ci.yml)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 [![AI Agent Friendly](https://img.shields.io/badge/AI%20agents-welcome-purple.svg)](AGENTS.md)

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "typecheck": "tsc --noEmit",
     "format": "prettier --write ."
   },
   "keywords": [


### PR DESCRIPTION
## Why this is high-impact

After reviewing the open PR queue, one gap stood out: contributors are manually claiming `pnpm build` passes, but there are no automated checks on PRs.

That means regressions can slip in silently, and maintainers have to manually verify every contribution.

This PR adds a visible, reliable quality gate that gives maintainers and contributors immediate confidence.

## What this PR adds

- ? **GitHub Actions CI workflow** at `.github/workflows/ci.yml`
- ? Runs on **pull requests** and **pushes to main**
- ? Uses **Node 22 + pnpm cache** for reproducible, faster installs
- ? Runs:
  - `pnpm typecheck`
  - `pnpm build`
- ? Adds a **CI badge** to `README.md` so repo quality status is visible at a glance
- ? Adds a dedicated `typecheck` script to `package.json`

## Why this matters for current PRs

This immediately upgrades the review experience for all open feature PRs (ThemeSwitcher, TerminalTree keyboard nav, etc.):

- Reviewers can focus on design/API quality instead of rerunning basics locally
- Contributors get fast feedback before merge
- The project looks significantly more mature and trustworthy to new visitors

## Validation

Ran locally on this branch:

- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm build`

Both pass successfully.

---

If useful, I can follow up with a second PR to add a modern ESLint setup compatible with Next 16 (since `next lint` behavior changed), so linting can be included in CI as well.
