### PR TITLE
fix: set turbopack root to repo directory

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,9 @@ const nextConfig: NextConfig = {
   reactStrictMode: true,
   poweredByHeader: false,
   headers: securityHeaders,
+  turbopack: {
+    root: __dirname,
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
## Summary

This PR fixes the noisy Next.js build warning about an inferred workspace root caused by multiple lockfiles on the machine.

By explicitly setting `turbopack.root` to this repository directory, builds become deterministic and cleaner in local/dev/CI output.

## Changes

- Update `next.config.ts`
- Add:
  - `turbopack.root = __dirname`

## Why this helps

- Removes distracting build warnings
- Prevents accidental root inference outside this repo
- Improves contributor confidence when running `pnpm build`

## Validation

- [x] `corepack pnpm build` passes
- [x] Warning no longer appears
