### PR TITLE
docs: add component status matrix to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,21 @@ export default function App() {
 - **TerminalTree** - File tree views → [Issue #9](../../issues/9)
 - **TerminalPrompt** - Interactive input → [Issue #12](../../issues/12)
 
+## 📊 Component Status Matrix
+
+| Component | Status | Keyboard Support | Notes |
+|---|---|---|---|
+| `Terminal` | ✅ Stable | ✅ | Core window chrome + content container |
+| `TerminalCommand` | ✅ Stable | ✅ | Prompt + command line rendering |
+| `TerminalOutput` | ✅ Stable | ✅ | Semantic output colors + optional animation |
+| `TerminalSpinner` | ✅ Stable | ✅ | Braille spinner for async/loading states |
+| `TerminalTree` | 🧪 Beta | ✅ | Keyboard navigation recently added |
+| `TerminalPrompt` | 🧪 Beta | ✅ | Interactive prompt patterns |
+| `TerminalProgress` | 🧪 Beta | ✅ | Progress indicators |
+| `TerminalTable` | 🧪 Beta | ✅ | Terminal-style tabular data |
+
+> Legend: ✅ Stable = production-ready baseline, 🧪 Beta = usable with active iteration.
+
 ## 🎮 Live Demo
 
 [**→ View the Playground**](https://terminal-ui.vercel.app)


### PR DESCRIPTION
## Summary

Adds a **Component Status Matrix** to the README so newcomers can instantly see what is stable vs. still evolving.

## What changed

- Added a new `## Component Status Matrix` section
- Included status, keyboard support, and quick notes for major components
- Added a short legend for stable/beta terminology

## Why this matters

This makes the project feel much more productized:

- Faster onboarding for contributors
- Better expectations for adopters
- Cleaner communication of roadmap maturity

## Validation

- [x] README renders cleanly on GitHub
- [x] Table content is concise and scannable
