### PR TITLE
docs: add PR quality expectations to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,27 @@ pnpm run format
 pnpm run lint
 ```
 
+### PR Quality Expectations
+
+Before opening a PR, make sure your description is reviewer-friendly:
+
+- **Lead with impact**: what user/developer problem did you solve?
+- **List concrete changes**: 2-5 bullets is usually perfect
+- **Include validation commands**: paste exactly what you ran
+- **Add screenshots for UI changes**: before/after if possible
+- **Call out follow-ups**: mention intentionally deferred work
+
+Recommended structure:
+
+```markdown
+## Summary
+## Problem / Motivation
+## Changes
+## Validation
+## Screenshots (if UI)
+## Follow-ups
+```
+
 ### 6. Commit
 
 ```bash


### PR DESCRIPTION
## Summary

Adds a focused **PR Quality Expectations** section to `CONTRIBUTING.md`.

## What changed

- Added practical guidance for writing high-signal PR descriptions:
  - lead with impact
  - list concrete changes
  - include exact validation commands
  - add screenshots for UI updates
  - call out follow-ups/tradeoffs
- Included a recommended Markdown structure contributors can copy directly

## Why this matters

This raises the baseline quality of incoming PRs and reduces reviewer effort, especially for first-time contributors and AI-assisted submissions.

## Validation

- [x] Markdown renders cleanly
- [x] Guidance aligns with repo workflow
