### PR TITLE
ci: enforce conventional commit PR titles

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,26 @@
+name: PR Title Lint
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate-title:
+    name: Validate Conventional Commit PR title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check title format
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          echo "PR title: $PR_TITLE"
+          if [[ ! "$PR_TITLE" =~ ^(feat|fix|docs|style|refactor|test|chore|ci)(\([a-z0-9\-]+\))?:\ .+ ]]; then
+            echo "❌ PR title must follow Conventional Commits."
+            echo "Expected: type(scope): summary or type: summary"
+            echo "Example: feat(tree): add keyboard navigation"
+            exit 1
+          fi
+          echo "✅ PR title format looks good"


### PR DESCRIPTION
## Summary

Adds a lightweight CI workflow that validates pull request titles against a Conventional Commits pattern.

## What changed

- New workflow: `.github/workflows/pr-title.yml`
- Runs on PR open/edit/sync/reopen events
- Fails with clear guidance when title format is invalid
- Accepts titles like:
  - `feat: add ThemeSwitcher`
  - `fix(tree): handle collapsed parent navigation`

## Why this matters

Consistent PR titles improve changelog quality, release notes, and review clarity with almost zero maintenance cost.

## Validation

- [x] Workflow syntax is valid YAML
- [x] Regex accepts valid Conventional Commit title patterns
- [x] Failure message provides correction examples
