### PR TITLE
chore: add CODEOWNERS for review consistency

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Default owners for all files
+* @OpenKnots
+
+# CI and project governance
+.github/* @OpenKnots
+README.md @OpenKnots
+CONTRIBUTING.md @OpenKnots
+AGENTS.md @OpenKnots


### PR DESCRIPTION
## Summary

Adds a `.github/CODEOWNERS` file so reviews are routed consistently to maintainers for key project files.

## What changed

- Added default ownership for the repository
- Added explicit ownership for governance/docs paths:
  - `.github/*`
  - `README.md`
  - `CONTRIBUTING.md`
  - `AGENTS.md`

## Why this matters

- Ensures important repo/process changes are always seen by maintainers
- Reduces review ambiguity as contributor count grows
- Improves long-term maintainability with minimal overhead

## Validation

- [x] `CODEOWNERS` file is in the correct path (`.github/CODEOWNERS`)
- [x] Pattern syntax is valid and concise
