### PR TITLE
docs: add branch protection playbook for maintainers

### DIFF
--- a/.github/BRANCH_PROTECTION.md
+++ b/.github/BRANCH_PROTECTION.md
@@ -1,0 +1,39 @@
+# Branch Protection Playbook
+
+Use this to enable baseline protections for `main`.
+
+## Recommended settings
+
+- Require pull request before merging
+- Require at least **1 approval**
+- Dismiss stale approvals on new commits
+- Require status checks before merging:
+  - `Typecheck & Build`
+  - `Validate Conventional Commit PR title`
+- Require conversation resolution before merge
+- Restrict force pushes
+- Restrict branch deletion
+
+## GitHub UI path
+
+1. Repository Settings → Branches
+2. Add branch protection rule for `main`
+3. Enable the settings above
+
+## Optional: GitHub CLI/API (admin only)
+
+```bash
+gh api \
+  -X PUT \
+  repos/OpenKnots/terminal-ui/branches/main/protection \
+  -H "Accept: application/vnd.github+json" \
+  -f required_status_checks.strict=true \
+  -f required_status_checks.contexts[]='Typecheck & Build' \
+  -f required_status_checks.contexts[]='Validate Conventional Commit PR title' \
+  -f enforce_admins=true \
+  -F required_pull_request_reviews.dismiss_stale_reviews=true \
+  -F required_pull_request_reviews.required_approving_review_count=1 \
+  -f restrictions=
+```
+
+> Note: branch protection requires repo admin permissions.

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ We **love** contributions! This repo is designed for practice PRs.
 **For Humans:**
 - 📖 [CONTRIBUTING.md](CONTRIBUTING.md) - Contribution guidelines
 - 💡 [GOOD_FIRST_ISSUES.md](GOOD_FIRST_ISSUES.md) - Ideas for PRs
+- 🛡️ [.github/BRANCH_PROTECTION.md](.github/BRANCH_PROTECTION.md) - Recommended merge safeguards
 
 **For AI Agents:**
 - 🤖 [AGENTS.md](AGENTS.md) - Complete agent guide (start here!)


### PR DESCRIPTION
## Summary

Adds a clear **Branch Protection Playbook** so maintainers can enable strong merge safeguards on `main` in minutes.

## What changed

- Added `.github/BRANCH_PROTECTION.md` with:
  - recommended protection settings
  - exact GitHub UI path
  - optional `gh api` command for admins
- Linked the playbook from README contributor resources

## Why this matters

This closes the governance gap between "we have CI" and "CI is actually enforced before merge".

It helps ensure:

- no direct risky merges to `main`
- at least one reviewer signs off
- required checks pass before merge

## Validation

- [x] Markdown renders cleanly
- [x] Settings align with current CI checks and workflows
- [x] README link is added for discoverability
