### PR TITLE
fix: prevent theme switcher from overwriting saved theme on mount

### DIFF
--- a/components/theme-switcher.tsx
+++ b/components/theme-switcher.tsx
@@ -32,21 +32,28 @@ interface ThemeSwitcherProps {
  */
 export function ThemeSwitcher({ className = '' }: ThemeSwitcherProps) {
   const [theme, setTheme] = useState<ThemeId>('dracula')
+  const [mounted, setMounted] = useState(false)
   const validThemeIds = useMemo(() => new Set(THEME_OPTIONS.map((o) => o.id)), [])
 
   useEffect(() => {
+    setMounted(true)
     const saved = localStorage.getItem('terminal-theme')
     const attr = document.documentElement.getAttribute('data-theme')
     const initial = [saved, attr].find(
       (v): v is ThemeId => !!v && validThemeIds.has(v as ThemeId),
     )
-    if (initial) setTheme(initial)
+    if (initial) {
+      setTheme(initial)
+      // Apply immediately to avoid flash if state update takes a tick
+      document.documentElement.setAttribute('data-theme', initial)
+    }
   }, [validThemeIds])
 
   useEffect(() => {
+    if (!mounted) return
     document.documentElement.setAttribute('data-theme', theme)
     localStorage.setItem('terminal-theme', theme)
-  }, [theme])
+  }, [theme, mounted])
 
   return (
     <label className={`inline-flex items-center gap-2 text-sm font-mono text-[var(--term-fg-dim)] ${className}`.trim()}>


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where `ThemeSwitcher` overwrites the user's saved `localStorage` theme with the default `'dracula'` theme on the initial render. 

### Problem
Previously, the second `useEffect` in `ThemeSwitcher` ran immediately on mount, writing the initial component state (`'dracula'`) to `localStorage` before the first `useEffect` had a chance to apply the saved theme. This caused a flash of unstyled content and overwrote user preferences if the state didn't update fast enough or if multiple storage events fired.

### Solution
- Added a `mounted` state to defer the `localStorage` write until the component is fully mounted.
- Updated the initial effect to apply the saved theme directly to the DOM when found, preventing the visual flash while React batches the state update.

## Type of Change
- [x] 🐛 Bug fix

## Checklist
- [x] Component works correctly
- [x] Build passes