### PR TITLE
fix: avoid Google font fetch failures during build

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,18 +1,5 @@
 import type { Metadata } from 'next'
-import { Inter, JetBrains_Mono } from 'next/font/google'
 import './globals.css'
-
-const inter = Inter({
-  subsets: ['latin'],
-  variable: '--font-inter',
-  display: 'swap',
-})
-
-const jetbrainsMono = JetBrains_Mono({
-  subsets: ['latin'],
-  variable: '--font-mono',
-  display: 'swap',
-})
 
 export const metadata: Metadata = {
   title: {
@@ -48,8 +35,8 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en" className={`${inter.variable} ${jetbrainsMono.variable}`}>
-      <body className={inter.className}>{children}</body>
+    <html lang="en">
+      <body>{children}</body>
     </html>
   )
 }


### PR DESCRIPTION
## Summary
- remove `next/font/google` usage from `app/layout.tsx`
- drop runtime dependency on fetching Inter and JetBrains Mono from Google Fonts during build
- keep existing CSS font stacks in `app/globals.css` as fallbacks

## Why
In restricted or offline build environments, `next/font/google` fetches can fail and break `pnpm run build`.

## Validation
- `pnpm run build` now succeeds in this environment without Google Fonts fetch errors

## Tracking
- Refs clawgreen/terminal-ui#4
